### PR TITLE
Roni/fix crash when showing pdf417 barcode on RN 0.75+

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Uses React Native SVG
 npm install --save react-native-barcode-pdf417 react-native-svg
 ```
 
+### Link native code:
+
+```
+cd ios && pod install
+```
+
 ### Usage:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ React native component for pdf417 barcode. This module is based on https://githu
 ![screen shot 2017-06-19 at 2 52 59 pm](https://user-images.githubusercontent.com/902357/27300810-09ec0efa-54ff-11e7-971b-fef49851525f.png)
 
 ### Pre install:
-Uses React Native Community ART
+Uses React Native SVG
 
 ### Install:
 ```

--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ React native component for pdf417 barcode. This module is based on https://githu
 ![screen shot 2017-06-19 at 2 52 59 pm](https://user-images.githubusercontent.com/902357/27300810-09ec0efa-54ff-11e7-971b-fef49851525f.png)
 
 ### Pre install:
+
 Uses React Native SVG
 
 ### Install:
-```
-npm install --save react-native-barcode-pdf417
-```
 
-
+```
+npm install --save react-native-barcode-pdf417 react-native-svg
+```
 
 ### Usage:
+
 ```js
 import Barcode from "react-native-barcode-pdf417";
 //...
 <Barcode text="123124123" width={250} height={100} />
-
 ```
 
 LICENSE: MIT

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
-import { Text, View, ActivityIndicator, StyleSheet } from "react-native";
-import { Group, Shape, Surface } from '@react-native-community/art';
+import { View, ActivityIndicator, StyleSheet } from "react-native";
+import Svg, { G, Path } from "react-native-svg";
 
 import createPDF417 from "./lib/pdf417-min";
 
@@ -48,11 +48,11 @@ export default class RNPDF417 extends Component {
     });
 
     return (
-      <Surface width={width} height={height}>
-        <Group x={0} y={0}>
-          <Shape d={shapes} fill="#000000" />
-        </Group>
-      </Surface>
+      <Svg width={width} height={height}>
+        <G x={0} y={0}>
+          <Path d={shapes.join(" ")} fill="#000000" />
+        </G>
+      </Svg>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "peerDependencies": {
+    "react-native-svg": "*"
+  },
   "author": "",
   "license": "MIT"
 }


### PR DESCRIPTION
## Description

After updating to react-native 0.75+, react-native-community/art will generate some issues. The issue is [here](https://github.com/shipt/react-native-barcode-pdf417/blob/master/index.js#L51-L55), and the error message comes from [here](https://github.com/react-native-art/art/blob/e4a97cd03ec992182d326286be04b0b49267ffef/lib/Group.js#L31)
[@react-native-community/art](https://github.com/react-native-art/art) is not supported since 2021, so I don't think it's worth trying to fix the issue in there, as they suggest using react-native-svg or skia.

### Crash on iOS and some warnings on iOS with RN 0.75+
<img width="250" src="https://github.com/user-attachments/assets/61f8e8ca-18c6-432f-8e8a-066f4365ec42" />

<img width="250" src="https://github.com/user-attachments/assets/2a38db4e-53e0-4342-8b2d-505ed282f82f" />
<img width="250" src="https://github.com/user-attachments/assets/c14efeb1-367c-4dc4-befe-88cd07b5b024" />



### Build error on Android with RN 0.75+
```
BUILD FAILED in 2s
error Failed to install the app. Command failed with exit code 1: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
/Users/ronidecastro/Documents/Pdf417ExampleLatest/node_modules/@react-native-community/art/android/src/main/java/com/reactnativecommunity/art/ARTShapeShadowNode.java:25: error: cannot find symbol
import static com.facebook.react.common.ArrayUtils.copyArray; ^ symbol: class ArrayUtils location: package com.facebook.react.common
/Users/ronidecastro/Documents/Pdf417ExampleLatest/node_modules/@react-native-community/art/android/src/main/java/com/reactnativecommunity/art/ARTShapeShadowNode.java:25: error: static import only from classes and interfaces
import static com.facebook.react.common.ArrayUtils.copyArray;
^
/Users/ronidecastro/Documents/Pdf417ExampleLatest/node_modules/@react-native-community/art/android/src/main/java/com/reactnativecommunity/art/ARTRenderableViewManager.java:21: error: ARTRenderableViewManager is not abstract and does not override abstract method prepareToRecycleView(ThemedReactContext,View) in ViewManager
public class ARTRenderableViewManager extends ViewManager<View, ReactShadowNode> { ^
Note: /Users/ronidecastro/Documents/Pdf417ExampleLatest/node_modules/@react-native-community/art/android/src/main/java/com/reactnativecommunity/art/ARTGroupShadowNode.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
```

## Solution
Replace with react-native-svg.

### Screenshots:
<img width="400" src="https://github.com/user-attachments/assets/93d5b59d-b171-40e6-b3b5-531f87ac0502" />

<img width="400" src="https://github.com/user-attachments/assets/67243406-e395-4881-ad60-4b76eb6053a8" />


### Code used to test (Tested with react-native-svg 15.9.0 and 15.11.1 and react-native 0.75.4, 0.74.7 and 0.77.0):
```js
    "react-native-barcode-pdf417": "github:roni-castro-shipt/react-native-barcode-pdf417#Roni/fix-crash-when-showing-pdf417-barcode",
    "react-native-svg": "15.9.0"
```

```js
import React from 'react';
import {SafeAreaView, ScrollView, Text, View} from 'react-native';
import Barcode from 'react-native-barcode-pdf417';

function App() {
  const barcodeTexts = [
    '123124123',
    'This is a PDF417 by TEC IT, a two dimensional barcode format used to store large amounts of data in a compact and reliable way.\nBreak line.',
    '{"key1": "value1", "key2": "value2", "number": 123 }',
    '123456{"fn":"Roni","ln":"Castro","id":"123456789","oi":"changed"}abc12345',
  ];

  return (
    <SafeAreaView style={{flex: 1}}>
      <ScrollView contentContainerStyle={{gap: 10, padding: 24}}>
        {barcodeTexts.map((text, index) => (
          <View key={index}>
            <Text>Text being rendered: {text}</Text>
            <Barcode text={text} width={250} height={100} />
          </View>
        ))}
      </ScrollView>
    </SafeAreaView>
  );
}

export default App;
```




